### PR TITLE
Update de_DE.json, remove key mapping for key '186' -> ü/Ü

### DIFF
--- a/lib/keymaps/de_DE.json
+++ b/lib/keymaps/de_DE.json
@@ -44,10 +44,6 @@
     "81": {
         "alted": 64
     },
-    "186": {
-        "unshifted": 250,
-        "shifted": 220
-    },
     "187": {
         "unshifted": 43,
         "shifted": 42,


### PR DESCRIPTION
Just removed the keymapping for key "186" from de_DE.json in order to fix that issue which prints '\' instead of capital 'Ü'. -> #46
Just thought about atom's default behaviour. By default ü & Ü works fine. Therefore I thought that those mapping probably is not required at all.
Tried this on my machine, works for me.
